### PR TITLE
Added floor and ceil function for math library

### DIFF
--- a/all.hhs
+++ b/all.hhs
@@ -27,6 +27,8 @@
  *import math:ndim 
  //import math:ones --> base
  //import math:power --> base
+ //import math:floor --> base
+ //import math:ceil --> base
  *import math:QR
  *import math:shape 
  *import math:sum

--- a/ceil._test.hhs
+++ b/ceil._test.hhs
@@ -1,0 +1,44 @@
+
+*import math:ceil
+
+function ceil_test() {
+    // test scenario 1: integer test
+    // testset setup
+    let testSet1 = [1, -1, 0, -0, 1.1, -1.1, 1.0, -1.0];
+    let expectedVal1 = [1, -1, 0, -0, 2, -1, 1, -1];
+    // test process
+    for (let i = 0; i < testSet1.length; i++) {
+      if (floor(testSet1[i]) !== expectedVal1[i]) {
+        throw new Error("ceil integer test has failed on testcase: " + testSet1[i] +
+        "\noutput " + floor(testSet1[i]) + " while " + expectedVal1[i] + " is expected.");
+      }
+    }
+
+    // test scenario 2: 1d array test
+    // testset setup
+    let testSet2 = [1, -1, 0, -0, 1.1, -1.1, 1.0, -1.0];
+    let expectedVal2 = mat([[1, -1, 0, -0, 2, -1, 1, -1]]);
+    // test process
+    if (!(floor(testSet2) === expectedVal2)) {
+      throw new Error("ceil 1d array test has failed");
+    }
+
+    // test scenario 3: 2d array test
+    // testset setup
+    let testSet3 = [[1, -1, 0, -0], [1.1, -1.1, 1.0, -1.0]];
+    let expectedVal3 = mat([[1, -1, 0, -0], [2, -1, 1, -1]]);
+    // test process
+    if (!(floor(testSet3) === expectedVal3)) {
+      throw new Error("ceil 2d array test has failed");
+    }
+
+    // test scenario 4: Mat test
+    // testset setup
+    let testSet4 = mat([[1, -1, 0, -0], [1.1, -1.1, 1.0, -1.0]]);
+    let expectedVal4 = mat([[1, -1, 0, -0], [2, -1, 1, -1]]);
+    // test process
+    if (!(floor(testSet4) === expectedVal4)) {
+      throw new Error("ceil Mat test has failed");
+    }
+
+  }

--- a/ceil.hhs
+++ b/ceil.hhs
@@ -1,0 +1,65 @@
+/**
+* @author Blake Wang
+* @params input - The structure with elements to be rounded toward positive infinity. Can be a number, 1d array, 2d array, Mat, Tensor.
+* @returns a number rounded to positive infinity if input is a number, a Mat with all elements rounded to positive infinity if input is a 1d array, 2d array, Mat or Tensor.
+*
+*
+*
+*/
+
+*import math:is_number
+
+function ceil(input) {
+  // if input is a Mat, Tensor or 2d array
+  let in_type = ((input instanceof Mat || input instanceof Tensor))
+  if (in_type || (input instanceof Array && input[0] instanceof Array)) {
+    // matrix & tensor to js array
+    if (in_type) {
+      input = input.val;
+    }
+    // loop through all elements to round element toward negative infinity
+    for (let i = 0; i < input.length; i++) {
+      for (let j = 0; j < input[i].length; j++) {
+        if (is_number(input[i][j])) {
+          if (input[i][j] >= 0){
+            input[i][j] = (input[i][j] % 1 === 0 ? parseInt(input[i][j]) : parseInt(input[i][j]) + 1);
+          }else {
+            input[i][j] = parseInt(input[i][j]);
+          }
+        }else {
+          input[i][j] = NaN;
+        }
+      }
+    }
+    return mat(input);
+  }
+
+  // when input is a 1d array
+  if (input instanceof Array && !Array.isArray(input[0])) {
+    for (let i = 0; i < input.length; i++) {
+      if (is_number(input[i])) {
+        if (input[i] >= 0){
+          input[i] = (input[i] % 1 === 0 ? parseInt(input[i]) : parseInt(input[i]) + 1);
+        }else {
+          input[i] = parseInt(input[i]);
+        }
+      }else {
+        input[i] = NaN;
+      }
+    }
+    return mat(input);
+  }  
+
+  // when input is a number
+  if (is_number(input)) {
+    if (input >= 0){
+      return (input % 1 === 0 ? parseInt(input) : parseInt(input) + 1);
+    }else {
+      return parseInt(input);
+    }
+  }else {
+    return NaN;
+  }
+}
+
+

--- a/floor.hhs
+++ b/floor.hhs
@@ -1,0 +1,65 @@
+/**
+* @author Blake Wang
+* @params input - The structure with elements to be rounded toward negative infinity. Can be a number, 1d array, 2d array, Mat, Tensor.
+* @returns a number rounded to negative infinity if input is a number, a Mat with all elements rounded to negative infinity if input is a 1d array, 2d array, Mat or Tensor.
+*
+*
+*
+*/
+
+*import math: is_number
+
+function floor(input) {
+
+  // if input is a Mat, Tensor or 2d array
+  let in_type = ((input instanceof Mat || input instanceof Tensor))
+  if (in_type || (input instanceof Array && input[0] instanceof Array)) {
+    // matrix & tensor to js array
+    if (in_type) {
+      input = input.val;
+    }
+    // loop through all elements to round element toward negative infinity
+    for (let i = 0; i < input.length; i++) {
+      for (let j = 0; j < input[i].length; j++) {
+        if (is_number(input[i][j])) {
+          if (input[i][j] >= 0){
+            input[i][j] = parseInt(input[i][j]);
+          } else {
+            input[i][j] = (input[i][j] % 1 === 0 ? parseInt(input[i][j]) : parseInt(input[i][j]) - 1);
+          }
+        }else {
+          input[i][j] = NaN;
+        }
+      }
+    }
+    return mat(input);
+  }
+
+  // when input is a 1d array
+  if (input instanceof Array && !Array.isArray(input[0])) {
+    for (let i = 0; i < input.length; i++) {
+      if (is_number(input[i])) {
+        if (input[i] >= 0){
+          input[i] = parseInt(input[i]);
+        } else {
+          input[i] = (input[i] % 1 === 0 ? parseInt(input[i]) : parseInt(input[i]) - 1);
+        }
+      }else {
+        input[i] = NaN;
+      }
+    }
+    return mat(input);
+  }
+
+  // when input is a number
+  if (is_number(input)) {
+    if (input >= 0){
+      return parseInt(input);
+    } else {
+      return (input % 1 === 0 ? parseInt(input) : parseInt(input) - 1);
+    }
+  }else {
+    return NaN;
+  }
+}
+

--- a/floor_test.hhs
+++ b/floor_test.hhs
@@ -1,0 +1,45 @@
+
+*import math:floor
+
+function floor_test() {
+    // test scenario 1: integer test
+    // testset setup
+    let testSet1 = [1, -1, 0, -0, 1.1, -1.1, 1.0, -1.0];
+    let expectedVal1 = [1, -1, 0, 0, 1, -2, 1, -1];
+    // test process
+    for (let i = 0; i < testSet1.length; i++) {
+      if (floor(testSet1[i]) !== expectedVal1[i]) {
+        throw new Error("floor integer test has failed on testcase: " + testSet1[i] +
+        "\noutput " + floor(testSet1[i]) + " while " + expectedVal1[i] + " is expected.");
+      }
+    }
+
+    // test scenario 2: 1d array test
+    // testset setup
+    let testSet2 = [1, -1, 0, -0, 1.1, -1.1, 1.0, -1.0];
+    let expectedVal2 = mat([[1, -1, 0, 0, 1, -2, 1, -1]]);
+    // test process
+    if (!(floor(testSet2) === expectedVal2)) {
+      throw new Error("floor 1d array test has failed");
+    }
+
+    // test scenario 3: 2d array test
+    // testset setup
+    let testSet3 = [[1, -1, 0, -0], [1.1, -1.1, 1.0, -1.0]];
+    let expectedVal3 = mat([[1, -1, 0, 0], [1, -2, 1, -1]]);
+    // test process
+    if (!(floor(testSet3) === expectedVal3)) {
+      throw new Error("floor 2d array test has failed");
+    }
+
+    // test scenario 4: Mat test
+    // testset setup
+    let testSet4 = mat([[1, -1, 0, -0], [1.1, -1.1, 1.0, -1.0]]);
+    let expectedVal4 = mat([[1, -1, 0, 0], [1, -2, 1, -1]]);
+    // test process
+    if (!(floor(testSet4) === expectedVal4)) {
+      throw new Error("floor Mat test has failed");
+    }
+
+  }
+  

--- a/test.hhs
+++ b/test.hhs
@@ -20,6 +20,8 @@
 *import math:transpose_test
 *import math:usolve_test
 *import math:gcd_test
+//*import math:floor_test --> base
+//*import math:ceil_test --> base
 
 
 function test(){
@@ -41,6 +43,8 @@ function test(){
   transpose_test();
   usolve_test();
   gcd_test();
+  //floor_test();
+  //ceil_test();
   
   print("All test cases passed!")
 }


### PR DESCRIPTION
It seems that @lidangzzz has a plan to delete floor and ceil function from base. So, I contribute floor and ceil function to the math library which could replace old floor and ceil function in base.

For floor and ceil functions in base, if the input is a number, it will return a Mat object. I think it is not an ideal design.
For floor and ceil functions that I contributed, when the input is a number, it will return a number. When the input is a 1d array/ 2d array/ Mat/ Tensor, it will return a Mat object with a similar shape.